### PR TITLE
Make `AbstractMassProfile` and subtypes parametric

### DIFF
--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -7,11 +7,11 @@ import GalaxyProfiles:AbstractDensity
 
 ```@example guide
 """
-    SingularIsothermalSphere(ρ0::Real,rs::Real)
+    SingularIsothermalSphere(ρ0::Real, rs::Real)
 
 Singular isothermal sphere profile. Fields are `ρ0,rs`. 
 """
-struct SingularIsothermalSphere{T<:Real} <: AbstractDensity
+struct SingularIsothermalSphere{T<:Real} <: AbstractDensity{T}
     ρ0::T
     rs::T
 end
@@ -21,14 +21,14 @@ nothing # hide
 You should add some info about the profile to the docstring. If you are creating a 2D surface density distribution, you should subtype `AbstractSurfaceDensity`. You should then define additional constructors for your type. To allow the call signature we listed in the docstring above, define
 
 ```@example guide
-SingularIsothermalSphere(ρ0::Real,rs::Real) = SingularIsothermalSphere(promote(ρ0,rs)...)
+SingularIsothermalSphere(ρ0::Real, rs::Real) = SingularIsothermalSphere(promote(ρ0, rs)...)
 nothing # hide
 ```
 
 such that we can do
 
 ```@example guide
-SingularIsothermalSphere(1.0,1)
+SingularIsothermalSphere(1.0, 1)
 ```
 
 It is also common to define constructors that will take the total mass and scale radius as inputs and compute the characteristic density; in this example,`ρ0`. See the implementation of [`GeneralIsothermal`](@ref) for an example of how to do this.
@@ -36,7 +36,7 @@ It is also common to define constructors that will take the total mass and scale
 Now you should define as many methods from the [Defined Methods](@ref methods) section as you need, starting with methods to retrieve the parameters,
 
 ```@example guide
-params(d::SingularIsothermalSphere) = (d.ρ0,d.rs)
+params(d::SingularIsothermalSphere) = (d.ρ0, d.rs)
 scale_radius(d::SingularIsothermalSphere) = d.rs
 nothing # hide
 ```
@@ -44,13 +44,13 @@ nothing # hide
 and then evaluation methods like
 
 ```@example guide
-function ρ(d::SingularIsothermalSphere,r::Real)
+function ρ(d::SingularIsothermalSphere, r::Real)
     ρ0, rs = params(d)
-    ρ0 * (r/rs)^-2
+    return ρ0 * (r/rs)^-2
 end
 nothing # hide
 ```
 
 We avoid accessing the fields of the types directly and use `params` and `scale_radius` instead so that internal fields of the types can be refactored later if necessary without having to redefine all the accompanying methods.
 
-When you are done writing your methods, you should define methods for your type that allow for `Unitful` quantities in the `src/units.jl` file. You should be able to follow the examples there with little problem. You should write tests under `GalaxyProfiles.jl/test` to validate the behavior of your type and methods. It is recommended that you make a new file, e.g. `test/mytype.jl`, then add `include("mytype.jl")` to the `test/runtests.jl` file. You should then edit `src/GalaxyProfiles.jl` to export your new type, in this example `SingularIsothermalSphere`. 
+When you are done writing your methods, you should define methods for your type that allow for `Unitful` quantities in the `src/units.jl` file. You should be able to follow the examples there with little problem. You should write tests under `GalaxyProfiles.jl/test` to validate the behavior of your type and methods. It is recommended that you make a new file, e.g. `test/mytype_tests.jl`, then add `include("mytype_tests.jl")` to the `test/runtests.jl` file. You should then edit `src/GalaxyProfiles.jl` to export your new type, in this example `SingularIsothermalSphere`. 

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -5,22 +5,22 @@ These common methods are defined for most density profiles, when possible.
 
 ```@docs
 ρ(::GalaxyProfiles.AbstractDensity,::Real)
-invρ(::GalaxyProfiles.AbstractDensity,::T,::NTuple{2,S}) where {T<:Real,S<:Real}
+invρ(::GalaxyProfiles.AbstractDensity{T},::S,::NTuple{2,V}) where {T<:Real,S<:Real,V<:Real}
 ∇ρ(::GalaxyProfiles.AbstractDensity,::Real)
 ρmean(::GalaxyProfiles.AbstractDensity,::Real)
-invρmean(::GalaxyProfiles.AbstractDensity,::T,::NTuple{2,S}) where {T<:Real,S<:Real}
+invρmean(::GalaxyProfiles.AbstractDensity{T},::S,::NTuple{2,V}) where {T<:Real,S<:Real,V<:Real}
 Σ(::GalaxyProfiles.AbstractMassProfile,::Real)
-invΣ(::GalaxyProfiles.AbstractMassProfile,::T,::NTuple{2,S}) where {T<:Real,S<:Real}
+invΣ(::GalaxyProfiles.AbstractMassProfile{T},::S,::NTuple{2,V}) where {T<:Real,S<:Real,V<:Real}
 ∇Σ(::GalaxyProfiles.AbstractMassProfile,::Real)
 Σmean(::GalaxyProfiles.AbstractMassProfile,::Real)
 M(::GalaxyProfiles.AbstractDensity,::Real)
-invM(::GalaxyProfiles.AbstractDensity,::T,::NTuple{2,S}) where {T<:Real,S<:Real}
+invM(::GalaxyProfiles.AbstractDensity{T},::S,::NTuple{2,V}) where {T<:Real,S<:Real,V<:Real}
 ∇M(::GalaxyProfiles.AbstractDensity,::Real)
 Mtot(::GalaxyProfiles.AbstractMassProfile)
 Mproj(::GalaxyProfiles.AbstractMassProfile,::Real)
 ∇Mproj(::GalaxyProfiles.AbstractMassProfile,::Real)
 invMproj(::GalaxyProfiles.AbstractMassProfile,::T,::NTuple{2,S}) where {T<:Real,S<:Real}
-dynamical_time(d::GalaxyProfiles.AbstractDensity, r::T) where {T <: Real}
+dynamical_time(d::GalaxyProfiles.AbstractDensity{T}, r::S) where {T <: Real, S <: Real}
 cdf2D
 cdf3D
 ccdf2D
@@ -29,14 +29,14 @@ quantile2D
 quantile3D
 cquantile2D
 cquantile3D(::GalaxyProfiles.AbstractDensity,::Real)
-Vcirc(::GalaxyProfiles.AbstractDensity,::Real)
+Vcirc(::GalaxyProfiles.AbstractDensity{T},::S) where {T<:Real,S<:Real}
 Vesc(::GalaxyProfiles.AbstractDensity,::Real)
 Vmax(::GalaxyProfiles.AbstractDensity)
 σr(::GalaxyProfiles.AbstractDensity,::Real,::Real)
 σlos(::GalaxyProfiles.AbstractDensity,::Real,::Real)
-Φ(::GalaxyProfiles.AbstractDensity,::Real)
-∇Φ(::GalaxyProfiles.AbstractDensity,::Real)
-∇∇Φ(::GalaxyProfiles.AbstractDensity,::Real)
+Φ(::GalaxyProfiles.AbstractDensity{T},::S) where {T<:Real,S<:Real}
+∇Φ(::GalaxyProfiles.AbstractDensity{T},::S) where {T<:Real,S<:Real}
+∇∇Φ(::GalaxyProfiles.AbstractDensity{T},::S) where {T<:Real,S<:Real}
 ```
 
 ## Private Methods

--- a/src/GalaxyProfiles.jl
+++ b/src/GalaxyProfiles.jl
@@ -8,15 +8,15 @@ using SpecialFunctions: gamma, gamma_inc, gamma_inc_inv
 using QuadGK: quadgk
 using Requires: @require
 
-""" Supertype for all mass profiles. """
-abstract type AbstractMassProfile end
+""" `AbstractMassProfile{T <: Real}`: abstract supertype for all mass profiles. """
+abstract type AbstractMassProfile{T <: Real} end
 Base.Broadcast.broadcastable(m::AbstractMassProfile) = Ref(m)
 
-""" Abstract type `(<:AbstractMassProfile)` for 3D density profiles. """
-abstract type AbstractDensity <: AbstractMassProfile end
+""" `AbstractDensity{T} <: AbstractMassProfile{T}`: abstract supertype for all 3D density profiles. """
+abstract type AbstractDensity{T} <: AbstractMassProfile{T} end
 
 """ Abstract type `(<:AbstractMassProfile)` for surface density profiles for which 3D quantities are not defined. Radii for instances of `AbstractSurfaceDensity` are always 2D. """
-abstract type AbstractSurfaceDensity <: AbstractMassProfile end
+abstract type AbstractSurfaceDensity{T} <: AbstractMassProfile{T} end
 
 # mutable struct UnitDefaults{T<:u.FreeUnits{S,u.𝐋,nothing} where S, V<:u.FreeUnits{Z,u.𝐌,nothing} where Z}
 #     length::T

--- a/src/common.jl
+++ b/src/common.jl
@@ -61,7 +61,17 @@ Solve for the radius `r` [kpc] at which the density [M⊙ kpc^-3] is `x` for den
 
 When this method is not specialized for `d`, it will use an interval bracketing method from [`Roots.jl`](https://github.com/JuliaMath/Roots.jl), requiring that `ρ(d,r)` be defined. For this method, `kws...` are passed to `Roots.find_zero`.
 """
-invρ(d::AbstractDensity, x::T, interval::NTuple{2,S}=(scale_radius(d)/100,100*scale_radius(d)); kws...) where {T<:Real, S<:Real} = (U = promote_type(T, S); x <= 0 ? throw(DomainError(x,"x must be > 0")) : find_zero(y->ρ(d,y)-x,(U(interval[1]),U(interval[2])); kws...))
+function invρ(d::AbstractDensity{T}, x::S,
+              interval::NTuple{2,V} =
+                  (scale_radius(d)/100, 100*scale_radius(d));
+              kws...) where {T <: Real, S <: Real, V <: Real}
+    U = promote_type(T, S, V)
+    if x <= 0
+        throw(DomainError(x, "x must be > 0"))
+    else
+        return find_zero(y->ρ(d,y)-x, (U(interval[1]), U(interval[2])); kws...)
+    end
+end
 """
     ∇ρ(d::AbstractDensity, r::Real)
     ∇ρ(uu::GalaxyProfiles.∇ρdimensionUnits, d::AbstractDensity, r::Real)
@@ -93,7 +103,17 @@ Solve for the radius `r` [kpc] inside which the average density is `x` [M⊙ kpc
 
 When this method is not specialized for `d`, it will use an interval bracketing method from [`Roots.jl`](https://github.com/JuliaMath/Roots.jl), requiring that `ρmean(d,r)` or `M(d,r)` be defined. For this method, `kws...` are passed to `Roots.find_zero`.
 """
-invρmean(d::AbstractDensity, x::T, interval::NTuple{2,S}=(scale_radius(d)/100,100*scale_radius(d)); kws...) where {T<:Real, S<:Real} = (U = promote_type(T, S); x <= 0 ? throw(DomainError(x,"x must be > 0")) : find_zero(y->ρmean(d,y)-x,(U(interval[1]), U(interval[2])); kws...))
+function invρmean(d::AbstractDensity{T}, x::S,
+                  interval::NTuple{2,V} =
+                      (scale_radius(d)/100, 100*scale_radius(d));
+                  kws...) where {T <: Real, S <: Real, V <: Real}
+    U = promote_type(T, S, V)
+    if x <= 0
+        throw(DomainError(x, "x must be > 0"))
+    else
+        return find_zero(y->ρmean(d,y)-x, (U(interval[1]), U(interval[2])); kws...)
+    end
+end
 """
     Σ(d::AbstractMassProfile, r::Real)
     Σ(uu::GalaxyProfiles.SurfaceDensityUnits, d::AbstractMassProfile, r::Real)
@@ -130,7 +150,7 @@ Returns the radial derivative of the surface density [M⊙ kpc^-3] of the mass p
 
 Returns the mean projected surface density [M⊙ kpc^-2] of the mass profile `d` inside the radius `r` [kpc]. The generic method uses projected enclosed mass divided by area: `Mproj(d::AbstractMassProfile,r::Real) / (π * r^2)`.
 """
-Σmean(d::AbstractMassProfile, r::T) where T <: Real = Mproj(d,r) / r^2 / π
+Σmean(d::AbstractMassProfile, r::Real) = Mproj(d,r) / r^2 / π
 """
     invΣ(d::AbstractMassProfile, x::Real)
     invΣ(d::AbstractMassProfile, x::Real,
@@ -144,9 +164,19 @@ Solve for the radius `r` [kpc] at which the surface density [M⊙ kpc^-2] is `x`
 
 When this method is not specialized for `d`, it will use an interval bracketing method from [`Roots.jl`](https://github.com/JuliaMath/Roots.jl), requiring that `Σ(d,r)` be defined. For this method, `kws...` are passed to `Roots.find_zero`.
 """
-invΣ(d::AbstractMassProfile, x::T, interval::NTuple{2,S}=(scale_radius(d)/100,100*scale_radius(d)); kws...) where {T<:Real, S<:Real} = (U = promote_type(T, S); x <= 0 ? throw(DomainError(x,"x must be > 0")) : find_zero(y->Σ(d,y)-x,(U(interval[1]), U(interval[2])); kws...))
+function invΣ(d::AbstractMassProfile{T}, x::S,
+              interval::NTuple{2,V} =
+                  (scale_radius(d)/100, 100*scale_radius(d));
+              kws...) where {T <: Real, S <: Real, V <: Real}
+    U = promote_type(T, S, V)
+    if x <= 0
+        throw(DomainError(x, "x must be > 0"))
+    else
+        return find_zero(y->Σ(d,y)-x, (U(interval[1]), U(interval[2])); kws...)
+    end
+end
 """
-    M(d::AbstractDensity, r::Real; kws...)
+    M(d::AbstractDensity, r::Real)
     M(uu::Unitful.MassUnits, d::AbstractDensity, r::Real)
     M(d::AbstractDensity, r::Unitful.Length)
     M(uu::Unitful.MassUnits, d::AbstractDensity, r::Unitful.Length)
@@ -157,9 +187,9 @@ Returns the total mass [M⊙] of the profile `d` enclosed within a spherical she
 M(\\lt R) = 4\\pi \\int_0^R r^2 ρ(r) dr
 ```
 
-When this method is not specialized for `d`, it will compute the numerical integral using `QuadGK.quadgk`; the provided `kws...` will be passed through. 
+When this method is not specialized for `d`, it will compute the numerical integral using `QuadGK.quadgk`.
 """
-M(d::AbstractDensity, r::Real; kws...) = quadgk(x->x^2 * ρ(d,x), zero(r), r)[1] * 4 * π
+M(d::AbstractDensity, r::Real) = quadgk(x->x^2 * ρ(d,x), zero(r), r)[1] * 4 * π
 """
     ∇M(d::AbstractDensity, r::Real)
     ∇M(uu::GalaxyProfiles.∇mdimensionUnits, d::AbstractDensity, r::Real)
@@ -168,7 +198,7 @@ M(d::AbstractDensity, r::Real; kws...) = quadgk(x->x^2 * ρ(d,x), zero(r), r)[1]
 
 The radial derivative of the enclosed mass [M⊙ kpc^-1] of profile `d` evaluated at radius `r`.
 """
-∇M(d::AbstractMassProfile, r::Real)
+∇M(d::AbstractDensity, r::Real)
 """
     invM(d::AbstractDensity, x::Real)
     invM(d::AbstractDensity, x::Real,
@@ -182,7 +212,17 @@ Solve for the radius `r` [kpc] at which the enclosed mass [M⊙] is `x` for prof
 
 When this method is not specialized for `d`, it will use an interval bracketing method from [`Roots.jl`](https://github.com/JuliaMath/Roots.jl), requiring that `M(d,r)` be defined. For this method, `kws...` are passed to `Roots.find_zero`.
 """
-invM(d::AbstractDensity, x::T, interval::NTuple{2,S}=(scale_radius(d)/100,100*scale_radius(d)); kws...) where {T<:Real, S<:Real} = (U = promote_type(T, S); x <= 0 ? throw(DomainError(x,"x must be > 0")) : find_zero(y->M(d,y)-x,(U(interval[1]), U(interval[2])); kws...))
+function invM(d::AbstractDensity{T}, x::S,
+              interval::NTuple{2,V} =
+                  (scale_radius(d)/100, 100*scale_radius(d));
+              kws...) where {T <: Real, S <: Real, V <: Real}
+    U = promote_type(T, S, V)
+    if x <= 0
+        throw(DomainError(x, "x must be > 0"))
+    else
+        find_zero(y->M(d,y)-x, (U(interval[1]), U(interval[2])); kws...)
+    end
+end
 """
     Mtot(d::AbstractMassProfile)
     Mtot(uu::Unitful.MassUnits, d::AbstractMassProfile)
@@ -224,7 +264,17 @@ Solve for the radius `r` [kpc] at which the line-of-sight projected enclosed mas
 
 When this method is not specialized for `d`, it will use an interval bracketing method from [`Roots.jl`](https://github.com/JuliaMath/Roots.jl), requiring that `M(d,r)` be defined. For this method, `kws...` are passed to `Roots.find_zero`.
 """
-invMproj(d::AbstractMassProfile, x::T, interval::NTuple{2,S}=(scale_radius(d)/100,100*scale_radius(d)); kws...) where {T<:Real, S<:Real} = (U = promote_type(T, S); x <= 0 ? throw(DomainError(x,"x must be > 0")) : find_zero(y->Mproj(d,y)-x,(U(interval[1]), U(interval[2])); kws...))
+function invMproj(d::AbstractMassProfile{T}, x::S,
+                  interval::NTuple{2,V} =
+                      (scale_radius(d)/100, 100*scale_radius(d));
+                  kws...) where {T <: Real, S <: Real, V <: Real}
+    U = promote_type(T, S, V)
+    if x <= 0
+        throw(DomainError(x, "x must be > 0"))
+    else
+        return find_zero(y->Mproj(d,y)-x, (U(interval[1]), U(interval[2])); kws...)
+    end
+end
 """
     dynamical_time(d::Union{AbstractDensity, AbstractMassProfile}, r::Real)
     dynamical_time(d::Union{AbstractDensity, AbstractMassProfile}, r::Unitful.Length)
@@ -245,18 +295,19 @@ t_\\text{dyn} \\left( r \\right) &= \\pi \\, \\sqrt{ \\frac{r^3}{4 \\, G \\, M \
 \\end{aligned}
 ```
 
-where ``M \\left( r \\right)`` is the mass enclosed inside radius ``r``, provided by the method [`M`](@ref). This equation is used when the argument `d::AbstractMassProfile`.
+where ``M \\left( r \\right)`` is the mass enclosed inside radius ``r``, provided by the method [`M`](@ref). This equation is used when the argument `d::AbstractMassProfile`, with the substitution of the projected mass [`Mproj`](@ref) for the 3-D enclosed mass [`M`](@ref), which is undefined for profiles that do not have `ρ` densities. 
 
 # Alternative Definitions
 Note that some authors prefer to omit the factor of ``\\sqrt{ \\frac{1}{16} } = 1/4`` in the denominator of the first equation above; this is, for example, the convention used by galpy. Dynamical times thus defined will be four times larger than those calculated by this method. 
 """
-function dynamical_time(d::AbstractDensity, r::T) where {T <: Real}
+function dynamical_time(d::AbstractDensity{T}, r::S) where {T <: Real, S <: Real}
+    U = promote_type(T, S)
     # constants.Gkpc has time units of 1/s^2; 31557600 is seconds in year to return value in yr
     # return sqrt(inv(GalaxyProfiles.ρmean(d, r)) * 3 * π / 16 / T(constants.Gkpc)) / 31557600
-    return sqrt(inv(GalaxyProfiles.ρmean(d, r)) * 3 * π) / (4 * 31557600 * sqrt(T(constants.Gkpc)))
+    return sqrt(inv(GalaxyProfiles.ρmean(d, r)) * 3 * π) / (4 * 31557600 * sqrt(U(constants.Gkpc)))
 end
-dynamical_time(d::AbstractMassProfile, r::T) where {T <: Real} =
-    π * sqrt(r^3 / M(d, r)) / (2 * 31557600 * sqrt(T(constants.Gkpc)))
+dynamical_time(d::AbstractMassProfile{T}, r::S) where {T <: Real, S <: Real} =
+    π * sqrt(r^3 / Mproj(d, r)) / (2 * 31557600 * sqrt(convert(promote_type(T,S), constants.Gkpc)))
     # π * sqrt( r^3 / 4 / T(constants.Gkpc) / M(d, r) ) / 31557600
 """
     cdf2D(d::AbstractMassProfile, r::Real)
@@ -328,7 +379,8 @@ v_c^2(r) = \\frac{G M(r)}{r} = r \\frac{d\\Phi}{dr} = r\\nabla\\Phi(r)
 
 By default uses `G` in units such that if `rs` and `r` are in kpc, the velocity ends up in `km/s`. For example, for [`GeneralIsothermal`](@ref) we have `[G] = [kpc * km^2 / Msun / s^2]` so that the velocity ends up in `km/s`. This method has a generic implementation of `sqrt( GalaxyProfiles.constants.Gvelkpc * M(d::AbstractDensity,r) / r)`.
 """
-Vcirc(d::AbstractDensity, r::T) where T <: Real = sqrt(T(constants.Gvelkpc) * M(d, r) / r)
+Vcirc(d::AbstractDensity{T}, r::S) where {T <: Real, S <: Real} =
+    sqrt(convert(promote_type(T,S), constants.Gvelkpc) * M(d, r) / r)
 """
     Vesc(d::AbstractDensity, r::Real)
     Vesc(uu::Unitful.VelocityUnits, d::AbstractDensity, r::Real)
@@ -375,8 +427,11 @@ and as ``\\frac{d\\Phi}{dr} = -G M(r) / r^2`` we can alternatively write
 which is the generic method as we expect ``M(r)`` to be more commonly available than ``\\frac{d\\Phi}{dr}``.
 """
 σr(d::AbstractDensity, r::T, β::S) where {T <: Real, S <: Real} = σr(d, promote(r, β)...)
-σr(d::AbstractDensity, r::T, β::T) where T <: Real =
-    sqrt(T(constants.Gvelkpc) * quadgk(x -> x^2(β-1) * ρ(d, x) * M(d, x), r, utilities.get_inf(r))[1] / r^(2β) / ρ(d, r))
+function σr(d::AbstractDensity{T}, r::S, β::S) where {T <: Real, S <: Real}
+    U = promote_type(T, S)
+    return sqrt(U(constants.Gvelkpc) / r^(2β) / ρ(d, r) *
+        quadgk(x -> x^2(β-1) * ρ(d, x) * M(d, x), r, utilities.get_inf(r))[1])
+end
 # function σr(d::AbstractDensity, r::T, β::T) where T <: Real
 #     value = sqrt(quadgk(x -> x^2β * ρ(d, x) * ∇Φ(d, x), r, utilities.get_inf(r))[1] / r^(2β) / ρ(d, r))
 #     # Convert from km^(1/2) kpc^(1/2) / s to km/s
@@ -391,8 +446,7 @@ Returns the line-of-sight projected velocity dispersion [km/s] of `d` at project
 \\sigma_{\\text{LOS}}^2 \\left( R \\right) = \\frac{2}{\\Sigma \\left( R \\right)} \\int_R^\\infty \\left(1 - \\beta \\frac{R^2}{r^2} \\right) \\frac{r \\, \\rho \\left( r \\right) \\, \\sigma_r^2 \\left( r \\right)}{\\sqrt{r^2 - R^2}} \\, dr
 ```
 """
-σlos(d::AbstractDensity, r::T, β::S) where {T <: Real, S <: Real} = σlos(d, promote(r, β)...)
-σlos(d::AbstractDensity, r::T, β::T) where T <: Real =
+σlos(d::AbstractDensity, r::Real, β::Real) =
     sqrt(2 / Σ(d,r) * quadgk(x->(1-β*(r/x)^2) * ρ(d,x) * σr(d,x,β)^2 * x / sqrt(x^2 - r^2), r, utilities.get_inf(r))[1])
 """
     Φ(d::AbstractDensity, r::Real)
@@ -429,9 +483,9 @@ The above integrals are not finite for some mass distributions (e.g., [`GeneralI
 ```
 such that ``\\Phi(R_s)\\equiv0``.
 """
-Φ(d::AbstractDensity, r::T) where T <: Real =
-    -T(constants.Gvelkpc) * (M(d,r)/r + quadgk(x->x * ρ(d,x), r, utilities.get_inf(T))[1] * 4 * π)
-    # -T(constants.Gvelkpc) * quadgk(x->M(d,x) / x^2, r, utilities.get_inf(T))[1]
+Φ(d::AbstractDensity{T}, r::S) where {T <: Real, S <: Real} =
+    -convert(promote_type(T,S), constants.Gvelkpc) *
+    (M(d,r)/r + quadgk(x->x * ρ(d,x), r, utilities.get_inf(T))[1] * 4 * π)
 """
     ∇Φ(d::AbstractDensity, r::Real)
     ∇Φ(uu::u.AccelerationUnits, d::AbstractDensity, r::Real)
@@ -467,7 +521,8 @@ We are thus taking a radial derivative of a radial integral. By applying the fun
 \\end{aligned}
 ```
 """
-∇Φ(d::AbstractDensity, r::T) where T <: Real = T(constants.Gvelkpc2) * M(d, r) / r^2
+∇Φ(d::AbstractDensity{T}, r::S) where {T <: Real, S <: Real} =
+    convert(promote_type(T,S), constants.Gvelkpc2) * M(d, r) / r^2
 """
     ∇∇Φ(d::AbstractDensity, r::Real)
     ∇∇Φ(uu::GalaxyProfiles.∇∇ΦdimensionUnits, d::AbstractDensity, r::Real)
@@ -491,8 +546,8 @@ Note that this is *not* the same as the Laplacian operator that appears the Pois
 
 which is not equivalent to the second radial gradient ``\\frac{\\partial^2 \\Phi(R)}{\\partial R^2}``, which is what this method returns.
 """
-∇∇Φ(d::AbstractDensity, r::T) where T <: Real =
-    T(constants.Gvelkpc2) * (∇M(d, r) / r^2 - 2M(d, r) / r^3)
+∇∇Φ(d::AbstractDensity{T}, r::S) where {T <: Real, S <: Real} =
+    convert(promote_type(T, S), constants.Gvelkpc2) * (∇M(d, r) / r^2 - 2M(d, r) / r^3)
 
 
 # check_vals(d::AbstractMassProfile,a::Number,T::DataType,S::DataType) = (promote_type(T,S), promote(params(d)...,a))

--- a/src/densities/corenfw.jl
+++ b/src/densities/corenfw.jl
@@ -36,7 +36,7 @@ where the core radius ``r_c`` and ``n``, which controls how shallow the core is 
 # See also
  - Constructor that uses galaxy properties, [`CoreNFWGalaxy`](@ref).
 """
-struct CoreNFW{T <: Real} <: AbstractDensity
+struct CoreNFW{T <: Real} <: AbstractDensity{T}
     # We'll save the NFW object rather than ρ0 and rs so we don't have to create it
     # every time we want to evaluate the non-cored NFW profile
     NFW::NFW{T}

--- a/src/densities/general_isothermal.jl
+++ b/src/densities/general_isothermal.jl
@@ -21,7 +21,7 @@ The following methods are specialized on this type:
 # See also
  - [`SIS`](@ref)
 """
-struct GeneralIsothermal{T <: Real} <: AbstractSurfaceDensity
+struct GeneralIsothermal{T <: Real} <: AbstractDensity{T}
     ρ0::T
     rs::T
     α::T

--- a/src/densities/nfw.jl
+++ b/src/densities/nfw.jl
@@ -13,7 +13,7 @@ The fields of `NFW` are `ρ0, rs`. The default units of `NFW` are `[ρ0] = [Msun
 The following public methods are defined on this type:
  - [`ρ`](@ref), [`invρ`](@ref), [`∇ρ`](@ref), [`ρmean`](@ref), [`Σ`](@ref), [`M`](@ref), [`∇M`](@ref), [`invM`](@ref), [`Mproj`](@ref), [`∇Mproj`](@ref), [`Vmax`](@ref), [`Vesc`](@ref), [`Φ`](@ref), [`∇Φ`](@ref), [`∇∇Φ`](@ref)
 """
-struct NFW{T<:Real} <: AbstractDensity
+struct NFW{T <: Real} <: AbstractDensity{T}
     ρ0::T
     rs::T
 end

--- a/src/densities/plummer.jl
+++ b/src/densities/plummer.jl
@@ -27,7 +27,7 @@ The default units of `Plummer` are `[M] = [Msun], [a, r] = [kpc]`. This is impor
 The following public methods are defined on this type:
  - [`Mtot`](@ref), [`ρ`](@ref), [`invρ`](@ref), [`∇ρ`](@ref), [`ρmean`](@ref), [`invρmean`](@ref), [`Σ`](@ref), [`∇Σ`](@ref), [`Σmean`](@ref), [`invΣ`](@ref), [`M`](@ref), [`∇M`](@ref), [`invM`](@ref), [`Mproj`](@ref), [`∇Mproj`](@ref), [`invMproj`](@ref), [`Vcirc`](@ref), [`Vesc`](@ref), [`Φ`](@ref), [`∇Φ`](@ref), [`∇∇Φ`](@ref), [`cdf2D`](@ref), [`cdf3D`](@ref), [`ccdf2D`](@ref), [`ccdf3D`](@ref), [`quantile2D`](@ref), [`quantile3D`](@ref), [`cquantile2D`](@ref), [`cquantile3D`](@ref).
 """
-struct Plummer{T <: Real} <: AbstractDensity
+struct Plummer{T <: Real} <: AbstractDensity{T}
     M::T
     a::T
 end
@@ -160,10 +160,10 @@ function invΣ(d::Plummer, x::Real)
     x, M, a = promote(x, Mtot(d), scale_radius(d))
     return a * sqrt(sqrt(M / x / π) / a - 1)
 end
-function M(d::Plummer, r::Real)
-    r, M, a = promote(r, Mtot(d), scale_radius(d))
-    return a * M * r^3 * sqrt(1 + (r/a)^2) / (a^2 + r^2)^2
-end
+# function M(d::Plummer, r::Real)
+#     r, M, a = promote(r, Mtot(d), scale_radius(d))
+#     return a * M * r^3 * sqrt(1 + (r/a)^2) / (a^2 + r^2)^2
+# end
 function ∇M(d::Plummer, r::Real)
     r, M, a = promote(r, Mtot(d), scale_radius(d))
     return 3 * a * M * r^2 / (a^2 + r^2)^2 / sqrt(1 + (r/a)^2)

--- a/src/surface_densities/exponential_disk.jl
+++ b/src/surface_densities/exponential_disk.jl
@@ -17,7 +17,7 @@ The following public methods are defined on this type:
 # See also
  - Convenience constructor [`ExponentialDiskDHI`](@ref).
 """
-struct ExponentialDisk{T<:Real} <: AbstractSurfaceDensity
+struct ExponentialDisk{T <: Real} <: AbstractSurfaceDensity{T}
     Σ0::T
     rs::T
     # ExponentialDisk{T}(ρ0::T,rs::T) where {T} = new{T}(μ,σ)

--- a/src/surface_densities/sersic.jl
+++ b/src/surface_densities/sersic.jl
@@ -10,7 +10,7 @@
 # end
 # Sersic(μ_e::Real, r_e::Real, n::Real, q::Real) = Sersic(promote(μ_e,r_e,n,q)...)
 
-struct Sersic{T<:Real} # <: AbstractSurfaceDensity
+struct Sersic{T <: Real} <: AbstractSurfaceDensity{T}
     Σ0::T
     r_e::T
     n::T


### PR DESCRIPTION
Previously `AbstractMassProfile` and subtypes were basic abstract types and did not have any parametric fields. This meant that when writing generic methods in `common.jl` I could not determine what the underlying numerical types in these objects were, which made propagating type promotions more difficult. This adds a parametric field to `AbstractMassProfile` and its subtypes and updates the generic implementations in `common.jl` to use this type information for better promotion.

Also fixes #5.